### PR TITLE
Add Indexers page with Envio

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -29,6 +29,7 @@
 * [📓 Smart Contracts](develop/smart-contracts/README.md)
   * [Remix](develop/smart-contracts/remix.md)
 * [⚒️ Common frameworks & Examples](develop/common-frameworks-and-examples.md)
+* [🗂️ Indexers](develop/indexers.md)
 * [🎱 Oracles](develop/oracles.md)
 * [💧 Testnet faucet](develop/testnet-faucet.md)
 * [🔩 Taraxa RPC Specs](develop/taraxa-rpc-specs.md)

--- a/develop/indexers.md
+++ b/develop/indexers.md
@@ -1,0 +1,14 @@
+# 🗂️ Indexers
+
+Here are a list of indexers currently integrated into the Taraxa ecosystem.
+
+## Envio
+
+Envio is the data layer for blockchain apps. It gives Taraxa developers the fastest, most flexible way to get real-time and historical onchain data, from a single GraphQL API to raw high-speed access, with managed hosting on Envio Cloud.
+
+Envio's HyperIndex natively supports indexing any EVM chain out of the box, including Taraxa, using your own RPC as the data source.
+
+Here are a few links to get you started with Envio on Taraxa.
+
+* Envio's [developer documentation](https://docs.envio.dev/)
+* Get started at [envio.dev](https://envio.dev/?utm_source=taraxa&utm_medium=partner-docs)


### PR DESCRIPTION
Adds a short Indexers page under Develop and links it in the sidebar. Envio's HyperIndex natively supports indexing any EVM chain out of the box, including Taraxa, using your own RPC as the data source.